### PR TITLE
Bump version of autograding-model to 6.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <module.name>${project.groupId}.quality.monitor</module.name>
     <docker-image-tag>${project.version}</docker-image-tag>
 
-    <autograding-model.version>5.4.0</autograding-model.version>
+    <autograding-model.version>6.0.0</autograding-model.version>
     <testcontainers.version>1.20.5</testcontainers.version>
     <github-api.version>1.327</github-api.version>
 


### PR DESCRIPTION
Use latest version of autograding the fixes rendering of tables.