### PR TITLE
Write GitHub comments even if the checks results fails

### DIFF
--- a/.github/workflows/quality-monitor.yml
+++ b/.github/workflows/quality-monitor.yml
@@ -93,18 +93,6 @@ jobs:
                   ]
                 },
                 {
-                  "name": "API Problems",
-                  "id": "api",
-                  "icon": "no_entry_sign",
-                  "tools": [
-                    {
-                      "id": "revapi",
-                      "sourcePath": "src/main/java",
-                      "pattern": "**/target/revapi-result.json"
-                    }
-                  ]
-                },
-                {
                   "name": "Vulnerabilities",
                   "id": "vulnerabilities",
                   "icon": "shield",

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: 'docker://uhafner/quality-monitor:2.5.1'
+  image: 'docker://uhafner/quality-monitor:2.5.2'
   env:
     CONFIG: ${{ inputs.config }}
     CHECKS_NAME: ${{ inputs.checks-name }}

--- a/doc/dependency-graph.puml
+++ b/doc/dependency-graph.puml
@@ -47,7 +47,7 @@ rectangle "commons-math3\n\n3.6.1" as org_apache_commons_commons_math3_jar
 rectangle "jackson-databind\n\n2.18.3" as com_fasterxml_jackson_core_jackson_databind_jar
 rectangle "jackson-annotations\n\n2.18.3" as com_fasterxml_jackson_core_jackson_annotations_jar
 rectangle "jackson-core\n\n2.18.3" as com_fasterxml_jackson_core_jackson_core_jar
-rectangle "quality-monitor\n\n2.5.1" as edu_hm_hafner_quality_monitor_jar
+rectangle "quality-monitor\n\n2.5.2" as edu_hm_hafner_quality_monitor_jar
 rectangle "github-api\n\n1.327" as org_kohsuke_github_api_jar
 rectangle "codingstyle\n\n5.9.0" as edu_hm_hafner_codingstyle_jar
 rectangle "spotbugs-annotations\n\n4.9.3" as com_github_spotbugs_spotbugs_annotations_jar

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>edu.hm.hafner</groupId>
   <artifactId>quality-monitor</artifactId>
-  <version>2.5.1</version>
+  <version>2.5.2</version>
   <packaging>jar</packaging>
 
   <scm>

--- a/src/test/java/edu/hm/hafner/grading/github/QualityMonitorDockerITest.java
+++ b/src/test/java/edu/hm/hafner/grading/github/QualityMonitorDockerITest.java
@@ -241,7 +241,7 @@ public class QualityMonitorDockerITest {
     }
 
     private GenericContainer<?> createContainer() {
-        return new GenericContainer<>(DockerImageName.parse("uhafner/quality-monitor:2.5.1"));
+        return new GenericContainer<>(DockerImageName.parse("uhafner/quality-monitor:2.5.2"));
     }
 
     private String readStandardOut(final GenericContainer<? extends GenericContainer<?>> container)


### PR DESCRIPTION
Currently, the GitHub PR comment is not written if the GitHub checks failed. It makes sense to write the comment in any case. Additionally, we need to write a detailed failure message to the log.