### PR TITLE
Use the default message if the HTTP response message is `null`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: 'docker://uhafner/quality-monitor:2.6.0-SNAPSHOT'
+  image: 'docker://uhafner/quality-monitor:2.5.3'
   env:
     CONFIG: ${{ inputs.config }}
     CHECKS_NAME: ${{ inputs.checks-name }}

--- a/doc/dependency-graph.puml
+++ b/doc/dependency-graph.puml
@@ -47,7 +47,7 @@ rectangle "commons-math3\n\n3.6.1" as org_apache_commons_commons_math3_jar
 rectangle "jackson-databind\n\n2.18.3" as com_fasterxml_jackson_core_jackson_databind_jar
 rectangle "jackson-annotations\n\n2.18.3" as com_fasterxml_jackson_core_jackson_annotations_jar
 rectangle "jackson-core\n\n2.18.3" as com_fasterxml_jackson_core_jackson_core_jar
-rectangle "quality-monitor\n\n2.6.0-SNAPSHOT" as edu_hm_hafner_quality_monitor_jar
+rectangle "quality-monitor\n\n2.5.3" as edu_hm_hafner_quality_monitor_jar
 rectangle "github-api\n\n1.327" as org_kohsuke_github_api_jar
 rectangle "codingstyle\n\n5.9.0" as edu_hm_hafner_codingstyle_jar
 rectangle "spotbugs-annotations\n\n4.9.3" as com_github_spotbugs_spotbugs_annotations_jar

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>edu.hm.hafner</groupId>
   <artifactId>quality-monitor</artifactId>
-  <version>2.6.0-SNAPSHOT</version>
+  <version>2.5.3</version>
   <packaging>jar</packaging>
 
   <scm>

--- a/src/main/java/edu/hm/hafner/grading/github/QualityMonitor.java
+++ b/src/main/java/edu/hm/hafner/grading/github/QualityMonitor.java
@@ -148,7 +148,7 @@ public class QualityMonitor extends AutoGradingRunner {
 
             var prNumber = getEnv("PR_NUMBER", log);
             if (!prNumber.isBlank()) { // optional PR comment
-                var footer = "Created by %s.%s".formatted(getVersionLink(log), checksResult);
+                var footer = "Created by %s. %s".formatted(getVersionLink(log), checksResult);
                 github.getRepository(repository)
                         .getPullRequest(Integer.parseInt(prNumber))
                         .comment(prSummary + "\n\n" + footer + "\n");
@@ -177,7 +177,7 @@ public class QualityMonitor extends AutoGradingRunner {
     private void logException(final FilteredLog log, final IOException exception, final String message) {
         String errorMessage;
         if (exception instanceof HttpException responseException) {
-            errorMessage = responseException.getResponseMessage();
+            errorMessage = StringUtils.defaultIfBlank(responseException.getResponseMessage(), exception.getMessage());
         }
         else {
             errorMessage = exception.getMessage();

--- a/src/test/java/edu/hm/hafner/grading/github/QualityMonitorDockerITest.java
+++ b/src/test/java/edu/hm/hafner/grading/github/QualityMonitorDockerITest.java
@@ -241,7 +241,7 @@ public class QualityMonitorDockerITest {
     }
 
     private GenericContainer<?> createContainer() {
-        return new GenericContainer<>(DockerImageName.parse("uhafner/quality-monitor:2.6.0-SNAPSHOT"));
+        return new GenericContainer<>(DockerImageName.parse("uhafner/quality-monitor:2.5.3"));
     }
 
     private String readStandardOut(final GenericContainer<? extends GenericContainer<?>> container)


### PR DESCRIPTION
It seems that GitHub API does not always return a useful message.