### PR TITLE
Add custom SHA support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ runs:
     MAX_COVERAGE_ANNOTATIONS: ${{ inputs.max-coverage-annotations }}
     TITLE_METRIC: ${{ inputs.title-metric }}
     QUALITY_GATES: ${{ inputs.quality-gates }}
-    CUSTOM_SHA: ${{ inputs.sha }}
+    SHA: ${{ inputs.sha }}
 
 branding:
   icon: check-square

--- a/src/main/java/edu/hm/hafner/grading/github/QualityMonitor.java
+++ b/src/main/java/edu/hm/hafner/grading/github/QualityMonitor.java
@@ -237,16 +237,16 @@ public class QualityMonitor extends AutoGradingRunner {
 
     /**
      * Gets the SHA to use for the quality monitor check. First checks for a custom SHA
-     * (CUSTOM_SHA) which takes precedence over the default GITHUB_SHA.
+     * (SHA) which takes precedence over the default GITHUB_SHA.
      * This allows workflows to override the SHA used for quality monitoring when needed.
      *
      * @param log the logger
      * @return the SHA to use for the check
      */
     private String getCustomSha(final FilteredLog log) {
-        String customSha = getEnv("CUSTOM_SHA", log);
+        String customSha = getEnv("SHA", log);
         if (!customSha.isBlank()) {
-            log.logInfo("Using custom SHA from CUSTOM_SHA: " + customSha);
+            log.logInfo("Using custom SHA from SHA: " + customSha);
             return customSha;
         }
         


### PR DESCRIPTION
closes https://github.com/uhafner/quality-monitor/issues/112
Add Custom SHA Support for Quality Monitor

When using the Quality Monitor action in pull request workflows, GitHub Actions often provides the merge commit SHA (GITHUB_SHA) instead of the actual PR head commit SHA. This causes quality checks to run against the wrong commit, leading to incorrect commit references in GitHub check runs

This PR adds support for a custom SHA input that allows workflows to override the default GITHUB_SHA behavior.
Changes Made
1. New Action Input
Added optional sha input parameter to action.yml
Accepts any commit SHA that workflows want to use for quality monitoring
Fully backward compatible - falls back to GITHUB_SHA when not provided
2. Environment Variable Mapping
Maps the sha input to CUSTOM_SHA environment variable

Example Usage
```
- uses: actions/quality-monitor@v4
  with:
    config: quality-config.json
    sha: ${{ github.event.pull_request.head.sha || github.sha }}
```