### PR TITLE
Use reference reports for delta computation if available

### DIFF
--- a/src/main/java/edu/hm/hafner/grading/github/QualityMonitor.java
+++ b/src/main/java/edu/hm/hafner/grading/github/QualityMonitor.java
@@ -47,6 +47,7 @@ public class QualityMonitor extends AutoGradingRunner {
     private static final String NO_TITLE = "none";
     private static final String DEFAULT_TITLE_METRIC = "line";
     private static final boolean SHOW_HEADERS_IN_CHECKS_DETAILS = false;
+    static final String REFERENCE_REPORTS = "reference-reports";
 
     /**
      * The public entry point for the action in the docker container simply calls the quality monitor.
@@ -410,6 +411,14 @@ public class QualityMonitor extends AutoGradingRunner {
 
     @Override
     protected Optional<Path> fetchDeltaReportsFromPreviousPipeline(final FilteredLog log) {
-        return Optional.empty(); // TODO: Implement fetching of delta reports from previous pipeline if needed
+        var referencePath = Path.of(REFERENCE_REPORTS);
+        if (Files.exists(referencePath)) {
+            log.logInfo("Creating delta with reference reports from " + referencePath.toAbsolutePath());
+
+            return Optional.of(referencePath);
+        }
+        log.logInfo("Skipping delta computation, no reference reports found at " + referencePath.toAbsolutePath());
+
+        return Optional.empty();
     }
 }

--- a/src/test/java/edu/hm/hafner/grading/github/QualityMonitorTest.java
+++ b/src/test/java/edu/hm/hafner/grading/github/QualityMonitorTest.java
@@ -2,6 +2,13 @@ package edu.hm.hafner.grading.github;
 
 import org.junit.jupiter.api.Test;
 
+import edu.hm.hafner.util.FilteredLog;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static edu.hm.hafner.grading.github.QualityMonitor.*;
 import static org.assertj.core.api.Assertions.*;
 
 class QualityMonitorTest {
@@ -10,5 +17,19 @@ class QualityMonitorTest {
         var qualityMonitor = new QualityMonitor();
 
         assertThat(qualityMonitor.getDefaultConfigurationPath()).isEqualTo("/default-no-score-config.json");
+    }
+
+    @Test
+    void shouldCheckReferenceReports() throws IOException {
+        var qualityMonitor = new QualityMonitor();
+
+        var log = new FilteredLog();
+
+        assertThat(qualityMonitor.fetchDeltaReportsFromPreviousPipeline(log)).isEmpty();
+
+        var referenceReports = Path.of(REFERENCE_REPORTS);
+        Files.createDirectory(referenceReports).toFile().deleteOnExit();
+
+        assertThat(qualityMonitor.fetchDeltaReportsFromPreviousPipeline(log)).contains(referenceReports);
     }
 }


### PR DESCRIPTION
Since https://github.com/uhafner/autograding-model/pull/557 the autograding model has an option to show the delta of the current build and a given reference build. To use this option we need to provide a path to the reference build results. 

This PR adds an hardcoded path `reference-reports` that will be checked for those reference reports. This path needs to be created by a PR or main branch workflow and filled with the stored artifacts. 

See [quality-monitor-comment-pr.yml](https://github.com/uhafner/codingstyle/blob/7bb85fa01f82d31e27046817780ec2d6bd9de01e/.github/workflows/quality-monitor-comment-pr.yml#L23-L31) for an example.

