### PR TITLE
Integrate download of reference reports into the action

### DIFF
--- a/.github/actions/download-reference/action.yml
+++ b/.github/actions/download-reference/action.yml
@@ -1,0 +1,67 @@
+name: 'Download Reference Reports'
+description: 'Downloads quality reports from the main branch and extracts run and commit URLs'
+
+inputs:
+  artifact-name:
+    description: 'Name of the artifact to download'
+    required: false
+    default: 'quality-reports'
+  path:
+    description: 'Path to download artifact to'
+    required: false
+    default: 'reference-reports'
+  workflow:
+    description: 'Workflow file to download artifacts from'
+    required: false
+    default: 'quality-monitor-build.yml'
+
+outputs:
+  commit_url:
+    description: 'URL of the reference commit'
+    value: ${{ steps.reference-info.outputs.commit_url }}
+  head_sha:
+    description: 'Commit SHA of the reference workflow run'
+    value: ${{ steps.reference-info.outputs.head_sha }}
+  run_id:
+    description: 'Run ID of the reference workflow run'
+    value: ${{ steps.reference-info.outputs.run_id }}
+  run_url:
+    description: 'URL of the reference workflow run'
+    value: ${{ steps.reference-info.outputs.run_url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Download reference reports from main branch
+      id: download-reference
+      uses: dawidd6/action-download-artifact@v21
+      with:
+        branch: main
+        check_artifacts: true
+        if_no_artifact_found: ignore
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.path }}
+        workflow: ${{ inputs.workflow }}
+
+    - name: Display reference artifact info
+      id: reference-info
+      shell: bash
+      run: |
+        run_id=$(echo '${{ steps.download-reference.outputs.artifacts }}' | jq -r '.[0].workflow_run.id // "unknown"')
+        echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+        
+        if [ "$run_id" != "unknown" ]; then
+          run_url="https://github.com/${{ github.repository }}/actions/runs/$run_id"
+          echo "run_url=$run_url" >> "$GITHUB_OUTPUT"
+        fi
+
+        head_sha=$(echo '${{ steps.download-reference.outputs.artifacts }}' | jq -r '.[0].workflow_run.head_sha // "unknown"')
+        echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+
+        if [ "$head_sha" != "unknown" ]; then
+          commit_url="https://github.com/${{ github.repository }}/commit/$head_sha"
+          echo "commit_url=$commit_url" >> "$GITHUB_OUTPUT"
+        fi
+        
+        echo "Downloaded artifact from Run $run_id ($run_url)"
+        echo "Downloaded artifact from Commit SHA $head_sha ($commit_url)"

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ runs:
         repository: ${{ inputs.repository }}
 
     - name: Run Quality Monitor
-      uses: docker://ghcr.io/uhafner/quality-monitor:4.14.0-SNAPSHOT
+      uses: docker://ghcr.io/uhafner/quality-monitor:4.14.0
       env:
         CHECKS_NAME: ${{ inputs.checks-name }}
         COMMENTS_STRATEGY: ${{ inputs.comments-strategy }}

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
   config:
     description: "Quality monitor JSON configuration (if not set, a default configuration will be used)"
     required: false
+  delta-enabled:
+    description: "Automatically download reference reports from the main branch and compute delta metrics (if not set, no delta metrics will be computed)"
+    required: false
+    default: 'false'
   github-api-url:
     description: "GitHub API URL (GITHUB_API_URL)"
     required: false
@@ -33,19 +37,13 @@ inputs:
     description: "Pull request number (if not set, PR comments will be skipped)"
     required: false
   quality-gates:
-    description: "Quality gates configuration as JSON (optional)"
-    required: false
-  reference-commit-url:
-    description: "Commit URL of the reference results that are used for delta calculation"
-    required: false
-  reference-run-url:
-    description: "Pipeline run URL of the reference results that are used for delta calculation"
+    description: "Quality gates configuration as JSON (if not set, quality is only monitored but no quality gates will be evaluated)"
     required: false
   sha:
     description: "Commit SHA to use for the quality check (if not set, GITHUB_SHA will be used)"
     required: false
   show-headers:
-    description: "Show headers for each subsection in the summary (if not set, headers are hidden)"
+    description: "Show headers for each subsection in the comment summary (if not set, headers are hidden)"
     required: false
   skip-annotations:
     description: "Skip the creation of annotations (for warnings and missed coverage) if not empty"
@@ -55,25 +53,34 @@ inputs:
     required: false
 
 runs:
-  using: 'docker'
-  image: 'docker://ghcr.io/uhafner/quality-monitor:4.14.0-SNAPSHOT'
-  env:
-    CHECKS_NAME: ${{ inputs.checks-name }}
-    COMMENTS_STRATEGY: ${{ inputs.comments-strategy }}
-    COMMIT_URL: ${{ inputs.reference-commit-url }}
-    CONFIG: ${{ inputs.config }}
-    GITHUB_API_URL: ${{ inputs.github-api-url }}
-    GITHUB_TOKEN: ${{ inputs.github-token }}
-    LOG_COMMENTS: ${{ inputs.log-comments }}
-    MAX_COVERAGE_ANNOTATIONS: ${{ inputs.max-coverage-annotations }}
-    MAX_WARNING_ANNOTATIONS: ${{ inputs.max-warning-annotations }}
-    PR_NUMBER: ${{ inputs.pr-number }}
-    QUALITY_GATES: ${{ inputs.quality-gates }}
-    RUN_URL: ${{ inputs.reference-run-url }}
-    SHA: ${{ inputs.sha }}
-    SHOW_HEADERS: ${{ inputs.show-headers }}
-    SKIP_ANNOTATIONS: ${{ inputs.skip-annotations }}
-    TITLE_METRIC: ${{ inputs.title-metric }}
+  using: composite
+  steps:
+    - name: Download reference reports from main branch
+      id: reference
+      if: ${{ inputs.download-reference == 'true' }}
+      uses: ./.github/actions/download-reference
+      with:
+        repository: ${{ inputs.repository }}
+
+    - name: Run Quality Monitor
+      uses: docker://ghcr.io/uhafner/quality-monitor:4.14.0-SNAPSHOT
+      env:
+        CHECKS_NAME: ${{ inputs.checks-name }}
+        COMMENTS_STRATEGY: ${{ inputs.comments-strategy }}
+        COMMIT_URL: ${{ inputs.delta-enabled == 'true' && steps.reference.outputs.commit_url }}
+        CONFIG: ${{ inputs.config }}
+        GITHUB_API_URL: ${{ inputs.github-api-url }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        LOG_COMMENTS: ${{ inputs.log-comments }}
+        MAX_COVERAGE_ANNOTATIONS: ${{ inputs.max-coverage-annotations }}
+        MAX_WARNING_ANNOTATIONS: ${{ inputs.max-warning-annotations }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        QUALITY_GATES: ${{ inputs.quality-gates }}
+        RUN_URL: ${{ inputs.delta-enabled == 'true' && steps.reference.outputs.run_url }}
+        SHA: ${{ inputs.sha }}
+        SHOW_HEADERS: ${{ inputs.show-headers }}
+        SKIP_ANNOTATIONS: ${{ inputs.skip-annotations }}
+        TITLE_METRIC: ${{ inputs.title-metric }}
 
 branding:
   icon: check-square

--- a/doc/dependency-graph.puml
+++ b/doc/dependency-graph.puml
@@ -48,7 +48,7 @@ rectangle "commons-math3\n\n3.6.1" as org_apache_commons_commons_math3_jar
 rectangle "jackson-databind\n\n3.1.3" as tools_jackson_core_jackson_databind_jar
 rectangle "jackson-annotations\n\n2.21" as com_fasterxml_jackson_core_jackson_annotations_jar
 rectangle "jackson-core\n\n3.1.3" as tools_jackson_core_jackson_core_jar
-rectangle "quality-monitor\n\n4.14.0-SNAPSHOT" as edu_hm_hafner_quality_monitor_jar
+rectangle "quality-monitor\n\n4.14.0" as edu_hm_hafner_quality_monitor_jar
 rectangle "jackson-databind\n\n2.21.3" as com_fasterxml_jackson_core_jackson_databind_jar
 rectangle "jackson-core\n\n2.21.3" as com_fasterxml_jackson_core_jackson_core_jar
 rectangle "github-api\n\n1.330" as org_kohsuke_github_api_jar

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>edu.hm.hafner</groupId>
   <artifactId>quality-monitor</artifactId>
-  <version>4.14.0-SNAPSHOT</version>
+  <version>4.14.0</version>
   <packaging>jar</packaging>
 
   <name>Quality Monitor GitHub Action</name>

--- a/src/test/java/edu/hm/hafner/grading/github/QualityMonitorDockerITest.java
+++ b/src/test/java/edu/hm/hafner/grading/github/QualityMonitorDockerITest.java
@@ -239,7 +239,7 @@ class QualityMonitorDockerITest {
     }
 
     private GenericContainer<?> createContainer() {
-        return new GenericContainer<>(DockerImageName.parse("uhafner/quality-monitor:4.14.0-SNAPSHOT"));
+        return new GenericContainer<>(DockerImageName.parse("uhafner/quality-monitor:4.14.0"));
     }
 
     private String readStandardOut(final GenericContainer<? extends GenericContainer<?>> container)


### PR DESCRIPTION
Reference build reports are required to compute the delta metrics for a merge request. The code to download these reports is now integrated into the quality monitor action so that users do not need to worry how to get these reports from the main branch pipeline.